### PR TITLE
Us 9 get all events

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::EventsController < ApplicationController
+
+  def index
+    render json: EventsFacade.return_events
+  end
+
+
+end

--- a/app/facades/events_facade.rb
+++ b/app/facades/events_facade.rb
@@ -1,0 +1,20 @@
+class EventsFacade
+
+  def self.return_events
+    response_obj = {}
+    response_obj["events"] = []
+    all_sports = Sport.all
+    all_sports.each do |sport|
+      sport_obj = {}
+      sport_obj["sport"] = sport.sport
+      sport_obj["events"] = []
+      sport.events.each do |event|
+        sport_obj["events"] << event.event
+      end
+      sport_obj
+      response_obj["events"] << sport_obj
+    end
+    response_obj
+  end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       get '/olympians', to: "olympians#index"
       get '/olympian_stats', to: "olympian_stats#index"
+      get '/events', to: "events#index"
     end
   end
 end

--- a/spec/requests/api/v1/get_all_events_spec.rb
+++ b/spec/requests/api/v1/get_all_events_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe "Endpoint returns all events with their parent sport record" do
+  before :each do
+    @sport_1 = Sport.create(sport: "Basketball")
+      @event_1 = @sport_1.events.create(event: "Men's Basketball")
+      @event_2 = @sport_1.events.create(event: "Women's Basketball")
+      @event_3 = @sport_1.events.create(event: "Half Court Basketball")
+    @sport_2 = Sport.create(sport: "Fencing")
+      @event_4 = @sport_2.events.create(event: "Men's Fencing")
+      @event_5 = @sport_2.events.create(event: "Women's Fencing")
+      @event_6 = @sport_2.events.create(event: "Half Court Fencing")
+    @sport_3 = Sport.create(sport: "Water Polo")
+      @event_7 = @sport_3.events.create(event: "Men's Water Polo")
+      @event_8 = @sport_3.events.create(event: "Women's Water Polo")
+      @event_9 = @sport_3.events.create(event: "Half Court Water Polo")
+  end
+  it "Returns all associated event associated with a sport" do
+
+    get '/api/v1/events'
+
+    expect(response).to be_successful
+
+    events = JSON.parse(response.body)
+
+    expect(events["events"].count).to eq(3)
+    expect(events["events"].first.keys).to eq(["sport", "events"])
+    expect(events["events"].last.keys).to eq(["sport", "events"])
+    expect(events["events"].first["events"].count).to eq(3)
+    expect(events["events"].last["events"].count).to eq(3)
+  end
+end

--- a/spec/requests/api/v1/olympian_stats_spec.rb
+++ b/spec/requests/api/v1/olympian_stats_spec.rb
@@ -20,7 +20,8 @@ describe "Return relevant olympic stats" do
     expect(response).to be_successful
 
     stats_obj = JSON.parse(response.body)
-    binding.pry
-    expect(stats_obj.keys).to eq(["pie"])
+
+    expect(stats_obj["olympian_stats"].keys).to eq(["total_competing_olympians", "average_weight", "average_age"])
+    expect(stats_obj["olympian_stats"]["average_weight"].keys).to eq(["unit", "male_olympians", "female_olympians"])
   end
 end


### PR DESCRIPTION
Completing user story 9 with functionality that returns all events with the associated sport as a heading in the response.